### PR TITLE
correct name of compiled binary

### DIFF
--- a/doc/compiling/linux.md
+++ b/doc/compiling/linux.md
@@ -88,11 +88,11 @@ Build a version that runs directly from the source directory:
 
 Run it:
 
-    ./bin/luanti
+    ./bin/cloakv4
 
 Run unit tests:
 
-    ./bin/luanti --run-unittests
+    ./bin/cloakv4 --run-unittests
 
 - Use `cmake . -LH` to see all CMake options and their current state.
 - If you want to install it system-wide (or are making a distribution package),


### PR DESCRIPTION
after compiling on debian the name of binary seems to be cloakv4 instead of luanti

i barely know how to use github sry if i messed something up